### PR TITLE
follow the show_percentage option, remove obsolete icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,12 +204,12 @@ require("pigeon").setup({
 			enabled = true,
 			format = "%H:%M",
 			posttext = "hrs",
-			icon = " ",
+			icon = "󰃰 ",
 		},
 		day = {
 			enabled = true,
 			format = "%A",
-			icon = " ",
+			icon = "󰃶 ",
 		},
 		date = {
 			enabled = true,
@@ -278,7 +278,12 @@ require("pigeon").setup({
 	volume = {
 		enabled = true,
 		show_percentage = false,
-		icon = "󱄠",
+		icons = {
+			low = "󰕿",
+			medium = "󰖀",
+			high = "󰕾",
+			mute = "󰝟",
+		},
 	},
 	temperature = {
 		enabled = true,

--- a/lua/pigeon/config.lua
+++ b/lua/pigeon/config.lua
@@ -12,7 +12,7 @@ local defaults = {
 	},
 	hostname = {
 		enabled = true,
-		icon = " ",
+		icon = " ",
 	},
 	datetime = {
 		enabled = true,
@@ -20,12 +20,12 @@ local defaults = {
 			enabled = true,
 			format = "%H:%M",
 			posttext = "hrs",
-			icon = " ",
+			icon = "󰃰 ",
 		},
 		day = {
 			enabled = true,
 			format = "%A",
-			icon = " ",
+			icon = "󰃶 ",
 		},
 		date = {
 			enabled = true,
@@ -76,25 +76,30 @@ local defaults = {
 				disconnected = "󰕑 ",
 			},
 		},
-    wifi = {
-      status = {
-        connected = "󰤪",
-        disconnected = "󰤫",
-        enabled = true,
-      },
-      essid = {
-        enabled = true,
-      },
-      bit_rate = {
-        enabled = true,
-        unit = "mbps",
-      }
-    },
+		wifi = {
+			status = {
+				connected = "󰤪",
+				disconnected = "󰤫",
+				enabled = true,
+			},
+			essid = {
+				enabled = true,
+			},
+			bit_rate = {
+				enabled = true,
+				unit = "mbps",
+			},
+		},
 	},
 	volume = {
 		enabled = true,
-		show_percentage = false,
-		icon = "󱄠",
+		show_percentage = true,
+		icons = {
+			low = "󰕿",
+			medium = "󰖀",
+			high = "󰕾",
+			mute = "󰖁",
+		},
 	},
 	temperature = {
 		enabled = true,

--- a/lua/pigeon/volume/init.lua
+++ b/lua/pigeon/volume/init.lua
@@ -8,6 +8,7 @@ function M.volume_job()
     cmd_right = "amixer sget Master | grep 'Right:' | awk -F'[][]' '{ print $2 }'"
     cmd_left = "amixer sget Master | grep 'Left:' | awk -F'[][]' '{ print $2 }'"
     mute = "amixer get Master | sed 5q | grep -q '[on]'"
+    -- mute = "amixer sget Master | grep 'Right:' | awk -F'[][]' '{ print $4 }'"
   elseif vim.fn.executable("pulsemixer") == 1 then
     cmd_right = "pulsemixer --get-volume | awk -F ' ' '{ print $1 }'"
     cmd_left = "pulsemixer --get-volume | awk -F ' ' '{ print $2 }'"
@@ -54,24 +55,41 @@ function M.volume_job()
   vim.fn.jobwait({ mute_job_id }, 0)
 end
 
+function M.select_icon(volume_level)
+  local lvl = tonumber(volume_level)
+  if lvl < 33 then
+    return volume.icons.low
+  elseif lvl >= 33 and lvl < 66 then
+    return volume.icons.medium
+  else
+    return volume.icons.high
+  end
+end
+
 function M.volume()
   M.volume_job()
-  local result = volume.icon .. " "
+  local result = ""
   if vim.g.volume_left then
-    result = result .. vim.g.volume_left .. " 󰏰"
+    result = result .. M.select_icon(vim.g.volume_left) .. " "
+    if volume.show_percentage then
+      result = result .. vim.g.volume_left .. " 󰏰"
+    end
   else
     result = result .. "..."
   end
 
   result = result .. "  "
   if vim.g.volume_right then
-    result = result .. vim.g.volume_right .. " 󰏰"
+    result = result .. M.select_icon(vim.g.volume_right) .. " "
+    if volume.show_percentage then
+      result = result .. vim.g.volume_right .. " 󰏰"
+    end
   else
     result = result .. "..."
   end
   local muted = vim.g.mute == "1" and true or false
 
-  return muted and "󰖁" or result
+  return muted and volume.icons.mute or result
 end
 
 require("pigeon.commands.volume").volume_commands()


### PR DESCRIPTION
Add icons for low, medium, and high volume levels. Respect the show_percentage option and remove obsolete icons from README.md and config.lua using [nerdfix](https://github.com/loichyan/nerdfix) Also, as seen in the video, mute doesn't work (tested for amixer only). I left the suggested command commented out in volume/init.lua file if it helps. 
[Screencast from 2023-09-05 00-08-00.webm](https://github.com/Pheon-Dev/pigeon/assets/100767853/0991cedf-761c-40f3-ae6c-7f8b596ac80b)
